### PR TITLE
404 on vertx url

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x build (to .vertx)....."
-  curl --max-time 320 --location $VERTX_URL | tar -xf
+  curl --max-time 320 --location $VERTX_URL | tar x
   mv vert* .vertx
   rm '.vertx/bin/vertx.bat'
   cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x build (to .vertx)....."
-  curl --max-time 320 --location $VERTX_URL | tar xf
+  curl --max-time 320 --location $VERTX_URL | tar -xf
   mv vert* .vertx
   rm '.vertx/bin/vertx.bat'
   cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x build (to .vertx)....."
-  curl --max-time 320 --location $VERTX_URL | tar x
+  curl --max-time 320 --location $VERTX_URL | tar xz
   mv vert* .vertx
   rm '.vertx/bin/vertx.bat'
   cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -41,7 +41,7 @@ VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x build (to .vertx)....."
-  curl --max-time 320 --location $VERTX_URL | tar xz
+  curl --max-time 320 --location $VERTX_URL | tar xf
   mv vert* .vertx
   rm '.vertx/bin/vertx.bat'
   cd $BUILD_DIR

--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,7 @@ if [ -d "$CACHE_DIR/.vertx" ]; then
   echo "done"
 fi
 
-VERTX_URL="http://vertx.io/downloads/vert.x-1.3.1.final.tar.gz"
+VERTX_URL="http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.tar.gz"
 
 if [ ! -d "$BUILD_DIR/.vertx" ]; then
   echo -n "-----> Installing Vert.x build (to .vertx)....."


### PR DESCRIPTION
I've set the vertx url to this one http://vert-x.github.io/vertx-downloads/downloads/vert.x-1.3.1.final.tar.gz because the old one is broken and obviousely the buildpack doesn't build correctly.
